### PR TITLE
Add runspace name

### DIFF
--- a/src/CompletionPredictor.cs
+++ b/src/CompletionPredictor.cs
@@ -26,7 +26,7 @@ public partial class CompletionPredictor : ICommandPredictor, IDisposable
     {
         _guid = new Guid(guid);
         _runspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault());
-        _runspace.Name = this.GetType().Name;
+        _runspace.Name = nameof(CompletionPredictor);
         _runspace.Open();
 
         PopulateInitialState();

--- a/src/CompletionPredictor.cs
+++ b/src/CompletionPredictor.cs
@@ -26,6 +26,7 @@ public partial class CompletionPredictor : ICommandPredictor, IDisposable
     {
         _guid = new Guid(guid);
         _runspace = RunspaceFactory.CreateRunspace(InitialSessionState.CreateDefault());
+        _runspace.Name = this.GetType().Name;
         _runspace.Open();
 
         PopulateInitialState();


### PR DESCRIPTION
# PR Summary

This PR sets the runspace name to `CompletionPredictor` to easily identify which runspace is used the predictor.

![image](https://user-images.githubusercontent.com/38873752/223163950-f91c2886-98d5-46a5-9a66-1f2c1cf5ca58.png)

## PR Context

Resolves #15
